### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release and Publish Docker image
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:
@@ -7,6 +10,8 @@ on:
 
 jobs:
   release_and_publish:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       # Check out the repository


### PR DESCRIPTION
Potential fix for [https://github.com/EEWBot/EEWBot/security/code-scanning/8](https://github.com/EEWBot/EEWBot/security/code-scanning/8)

To fix the problem, an explicit `permissions` block should be added to the workflow, restricting the default permissions for all jobs to the minimal required (usually `contents: read`). For jobs or steps requiring more permissions (such as `softprops/action-gh-release`, which needs to create a release), an elevated `permissions` block (e.g., `contents: write`) should be added for that job.

Specifically:
- At the workflow root, add `permissions: contents: read` (minimally required for code checkout, etc.).
- For the `release_and_publish` job (which creates a release), elevate `contents` to `write` for this job. If granular permission for releases is available, use just `contents: write` for this job.
- These changes go in `.github/workflows/release.yml`:
  - Add a root-level `permissions: contents: read`.
  - Add under the `release_and_publish:` job a `permissions: contents: write`.
- No changes to imports; only YAML structure is affected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
